### PR TITLE
Add whitespace after every terminal

### DIFF
--- a/src/Sentence.php
+++ b/src/Sentence.php
@@ -149,11 +149,20 @@ class Sentence
         $parts = [];
 
         $chars = preg_split('//u', $line, -1, PREG_SPLIT_NO_EMPTY); // This is UTF8 multibyte safe!
-        $is_terminal = in_array($chars[0], $this->terminals);
+        //add space after each terminal because every sentence ends with terminal and whitespace
+        $terminals = array_map(function($terminal)
+            {
+                return sprintf('%s ', $terminal);
+            },
+            $this->terminals
+        );
+        $is_terminal = in_array($chars[0], $terminals);
 
         $part = '';
-        foreach ($chars as $char) {
-            if (in_array($char, $this->terminals) !== $is_terminal) {
+        foreach ($chars as $key => $char) {
+            $nextChar = isset($chars[$key + 1]) ? $chars[$key + 1] : '';
+            $checkChar = sprintf('%s%s', $char, $nextChar); //try to find something like ". ", "! " or "? "
+            if (in_array($checkChar, $terminals) !== $is_terminal) {
                 $parts[] = $part;
                 $part = '';
                 $is_terminal = !$is_terminal;


### PR DESCRIPTION
I had a sentence like: Prices will go up for 8.6% and because of that it is expensive.
And it was split into:
-  Prices will go up for 8.
- 6% and because of that it is expensive.

But that is wrong. So the assumption is that every sentence ends with ". ", "! " or "? " -> with extra white space