### PR TITLE
Simplify multibyte trimming. Fixes #27

### DIFF
--- a/src/Multibyte.php
+++ b/src/Multibyte.php
@@ -56,7 +56,9 @@ class Multibyte
      */
     public static function trim($string)
     {
-        return mb_ereg_replace('^\s*([\s\S]*?)\s*$', '\1', $string);
+        $string = mb_ereg_replace('^\s*', '', $string); // left trim
+        $string = mb_ereg_replace('\s*$', '', $string); // right trim
+        return $string;
     }
 
     /**

--- a/tests/MultibyteTest.php
+++ b/tests/MultibyteTest.php
@@ -28,4 +28,22 @@ class MultibyteTest extends \PHPUnit_Framework_TestCase
             [['a', '-', 'b', '-', 'c'], '(-)', 'a-b-c', -1, PREG_SPLIT_DELIM_CAPTURE],
         ];
     }
+
+
+    /**
+     * @dataProvider dataTrim
+     */
+    public function testTrim($subject, $expected=null)
+    {
+        if ($expected === null) $expected = $subject;
+        $this->assertSame($expected, Multibyte::trim($subject));
+    }
+
+    public function dataTrim()
+    {
+        return [
+            ['^ Old    ^  New       ^'],
+            ['^ Old                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ^ New                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ^'],
+        ];
+    }
 }


### PR DESCRIPTION
Instead of trying to trim the string from both ends, keeping the middle intact by referencing it, this applies two operations on the left and right separately.

Since both regexes are anchored and no references have to be kept it shouldn't be any slower than before and I suspect it might even be faster (though I have not benchmarked it).

It is more robust for sure and passes my (limited) test case.